### PR TITLE
Prevent client duplicate

### DIFF
--- a/src/controllers/client.ts
+++ b/src/controllers/client.ts
@@ -42,7 +42,7 @@ export const create_client: Express.RequestHandler = async (req, res) => {
     const sheet = google.sheets("v4");    
 
     if (await check_dup_client(new_client.mac_address, new_client.alias)) {
-        res.end()
+        res.status(400).end()
     } else {
         const append_res = sheet.spreadsheets.values.append({
             spreadsheetId: process.env.SHEET_ID,

--- a/src/utils/clientDup.ts
+++ b/src/utils/clientDup.ts
@@ -1,6 +1,6 @@
 import { google } from "googleapis";
 import { CLIENT_SHEET_ID } from "../controllers/checkins";
-import { CheckIn } from "../models/checkin";
+import { Client } from "../models/client";
 import { serialize_rows, sheet_auth } from "../utils/sheets";
 
 export const check_dup_client = async (mac_address, alias) => {
@@ -9,18 +9,11 @@ export const check_dup_client = async (mac_address, alias) => {
     const read_result = await sheet.spreadsheets.values.get({
       spreadsheetId: process.env.SHEET_ID,
       auth: sheet_auth(),
-      range: `${CLIENT_SHEET_ID}!A1:B`
+      range: `${CLIENT_SHEET_ID}!A1:E`
     });
   
     const rows = read_result.data.values as string[][];
-    const ser = serialize_rows(rows) as Array<CheckIn>;
+    const ser = serialize_rows(rows) as Array<Client>;
 
-    for (let i = 0; i < ser.length; i++) {
-        const macI = ser.at(i)?.event
-        const aliasI = ser.at(i)?.student_id
-        if (macI == mac_address || aliasI == alias) {
-            return true;
-        }
-    }
-    return false;
+    return ser.findIndex(client => client.mac_address === mac_address || client.alias === alias) !== -1
 }

--- a/src/utils/clientDup.ts
+++ b/src/utils/clientDup.ts
@@ -1,0 +1,26 @@
+import { google } from "googleapis";
+import { CLIENT_SHEET_ID } from "../controllers/checkins";
+import { CheckIn } from "../models/checkin";
+import { serialize_rows, sheet_auth } from "../utils/sheets";
+
+export const check_dup_client = async (mac_address, alias) => {
+    const sheet = google.sheets("v4");
+  
+    const read_result = await sheet.spreadsheets.values.get({
+      spreadsheetId: process.env.SHEET_ID,
+      auth: sheet_auth(),
+      range: `${CLIENT_SHEET_ID}!A1:B`
+    });
+  
+    const rows = read_result.data.values as string[][];
+    const ser = serialize_rows(rows) as Array<CheckIn>;
+
+    for (let i = 0; i < ser.length; i++) {
+        const macI = ser.at(i)?.event
+        const aliasI = ser.at(i)?.student_id
+        if (macI == mac_address || aliasI == alias) {
+            return true;
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
I have no way to test this, but it has a lot of similar code to #23.  Just prevents you from creating a client with a mac address or alias that already exists in the table. Closes #20 