### PR TITLE
Set client status with ws

### DIFF
--- a/src/utils/heartbeat.ts
+++ b/src/utils/heartbeat.ts
@@ -8,8 +8,8 @@ export const initHeartbeat = (app) => {
     const ws = expressWS(app);
 
     ws.app.ws('/heartbeat', (ws, res) => {
+        let hb: Heartbeat
         ws.on('message', async (message: string) => {
-            let hb: Heartbeat
             try {
                 hb = JSON.parse(message);
             } catch (error) {
@@ -36,19 +36,54 @@ export const initHeartbeat = (app) => {
             const sheetIndex = clientIndex + 2;
 
             client.last_heartbeat = Date.now();
-            const row = [...Object.values(client)];
+            client.status = true;
+            
+            heartbeatToSheet(client, sheetIndex);
+        });
 
-            const request = {
-                spreadsheetId: process.env.SHEET_ID,
-                range: "Client!A" + sheetIndex + ":E" + sheetIndex,
-                valueInputOption: "RAW",
-                auth: sheet_auth(),
-                resource: {
-                    values: [row]
+        ws.on("close", async () => {
+            if (hb !== undefined) {
+                const sheet = google.sheets("v4");
+                const read_result = await sheet.spreadsheets.values.get({
+                    spreadsheetId: process.env.SHEET_ID,
+                    auth: sheet_auth(),
+                    range: `${CLIENT_SHEET_ID}!A1:E`
+                });
+    
+                const rows = read_result.data.values as string[][];
+                const ser = serialize_rows(rows) as Array<Client>;
+    
+                const clientIndex = ser.findIndex((r) => hb.mac_address === r.mac_address);
+    
+                if (clientIndex == -1) {
+                    return;
                 }
-            }
+    
+                let client = ser[clientIndex];
+                const sheetIndex = clientIndex + 2;
 
-            sheet.spreadsheets.values.update(request);
+                client.status = false;
+
+                heartbeatToSheet(client, sheetIndex);
+            }
         });
     })
+}
+
+const heartbeatToSheet = async (client: Client, sheetIndex: number) => {
+    const sheet = google.sheets("v4");
+
+    const row = [...Object.values(client)];
+
+    const request = {
+        spreadsheetId: process.env.SHEET_ID,
+        range: "Client!A" + sheetIndex + ":E" + sheetIndex,
+        valueInputOption: "RAW",
+        auth: sheet_auth(),
+        resource: {
+            values: [row]
+        }
+    }
+
+    sheet.spreadsheets.values.update(request);
 }


### PR DESCRIPTION
closes #33. Moved the sheet update into a separate function. When the heartbeat is sent the status is set to TRUE and when the WS closes the status is set to FALSE. With or without the right message, the backend stays open and will not create data where it doesn't match.